### PR TITLE
選択肢を上部に表示

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import Select, { OptionType } from "react-auto-scroll-time-select";
 | onChange         |              | (option: OptionType &#124; null) => void;            | Select change event                                         |
 | findOption       |              | (option: OptionType, input: InputValueType) => void; | An event that finds options to scroll from input characters |
 | isClearable      | true         | boolean                                              | If true, display the button to clear                        |
-| styles           |              | { select, control, ... }                             | See [Custom Style](/#custom-styles)                         |
+| styles           |              | { select, control, ... }                             | See [Custom Style](#custom-styles)                          |
 | menuPortalTarget |              |                                                      | Element to add selection menu                               |
 
 ## Custom Styles

--- a/src/components/molecules/Control/index.tsx
+++ b/src/components/molecules/Control/index.tsx
@@ -22,6 +22,7 @@ const Control = () => {
           display: "table",
           borderCollapse: "separate",
           borderSpacing: 0,
+          width: "100%",
         };
 
         return (

--- a/src/components/molecules/SelectOptions/index.tsx
+++ b/src/components/molecules/SelectOptions/index.tsx
@@ -14,6 +14,7 @@ interface IProps {
   options: OptionType[];
   findOption: (option: OptionType, input: InputValueType) => void;
   changeFocusOptionMenuIndex: (i: number) => void;
+  overFrameMenuPosition?: boolean;
 }
 
 class SelectOptions extends Component<IProps> {
@@ -50,11 +51,8 @@ class SelectOptions extends Component<IProps> {
             return <></>;
           }
 
-          const selectOptionsBaseStyle = {
-            margin: "4px 0",
+          let selectOptionsBaseStyle = {
             position: "absolute",
-            top: offsetHeight,
-            height: 200,
             width: "100%",
             overflowY: "scroll",
             background: "#fff",
@@ -64,13 +62,24 @@ class SelectOptions extends Component<IProps> {
               "0 4px 5px 0 rgba(0,0,0,0.14), 0 1px 10px 0 rgba(0,0,0,0.12), 0 2px 4px -1px rgba(0,0,0,0.2)",
           };
 
+          if (!this.props.overFrameMenuPosition) {
+            selectOptionsBaseStyle = {
+              ...selectOptionsBaseStyle,
+              ...{
+                top: offsetHeight,
+              },
+            };
+          }
+
           return (
             <div
-              className={css(
-                selectOptions
+              className={css({
+                ...(selectOptions
                   ? selectOptions(selectOptionsBaseStyle)
-                  : selectOptionsBaseStyle
-              )}
+                  : selectOptionsBaseStyle),
+                height: 200,
+                margin: "4px 0",
+              })}
             >
               <Scrollbars ref={this.props.scrollbarsRef}>
                 {options.map((option, i) => (

--- a/src/components/molecules/SelectOptionsPortal/index.tsx
+++ b/src/components/molecules/SelectOptionsPortal/index.tsx
@@ -23,20 +23,36 @@ const SelectOptionsPortal = () => {
           return <></>;
         }
 
+        let overFrameMenuPosition = false;
+
         const {
           left,
           top,
           width,
+          bottom: selectControlBottom,
         } = selectControlRef.current.getBoundingClientRect();
+        let positionTop = top;
+
+        if (menuOpen && menuPortalTarget && inputFormRef.current) {
+          const scrollbarHeight = 200 + 8;
+          const {
+            bottom: menuPortalBottom,
+          } = menuPortalTarget.getBoundingClientRect();
+
+          if (menuPortalBottom < selectControlBottom + scrollbarHeight) {
+            positionTop -= scrollbarHeight;
+            overFrameMenuPosition = true;
+          }
+        }
 
         return createPortal(
           <div
             className={css({
               left,
               position: "absolute",
-              top,
+              top: positionTop,
               width,
-              zIndex: 1,
+              zIndex: 9999,
               boxSizing: "border-box",
             })}
           >
@@ -49,6 +65,7 @@ const SelectOptionsPortal = () => {
               options={options}
               findOption={findOption}
               changeFocusOptionMenuIndex={changeFocusOptionMenuIndex}
+              overFrameMenuPosition={overFrameMenuPosition}
             />
           </div>,
           menuPortalTarget

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,7 +67,11 @@ class Select extends Component<IProps, IState> {
           let inputValue = input || "";
 
           if (inputValue.indexOf(":") < 0) {
-            return value.replace(":", "").indexOf(inputValue) > -1;
+            if (inputValue.length <= 2) {
+              return value.indexOf(inputValue + ":") > -1;
+            } else {
+              return value.replace(":", "").indexOf(inputValue) > -1;
+            }
           } else {
             return value.indexOf(inputValue) > -1;
           }
@@ -80,13 +84,15 @@ class Select extends Component<IProps, IState> {
   componentDidUpdate(prevProps: IProps) {
     if (
       prevProps.value !== this.props.value ||
+      (prevProps.value &&
+        this.props.value &&
+        (prevProps.value.label !== this.props.value.label ||
+          prevProps.value.value !== this.props.value.value)) ||
       prevProps.hourLimit !== this.props.hourLimit ||
       prevProps.span !== this.props.span
     ) {
       this.setState({
-        inputValue: this.props.value
-          ? this.props.value.value
-          : this.state.inputValue,
+        inputValue: this.props.value ? this.props.value.value : null,
         hourLimit: this.props.hourLimit || this.state.hourLimit,
         span: this.props.span || this.state.span,
       });


### PR DESCRIPTION
close #29 

セレクトの下に選択肢を表示する領域が確保されていない場合、上部に表示するように対応

※ `menuPortalTarget`指定時に限定
